### PR TITLE
Mark The Hive as FIPS Compliant in app metadata

### DIFF
--- a/thehive.json
+++ b/thehive.json
@@ -16,6 +16,7 @@
     "main_module": "thehive_connector.py",
     "min_phantom_version": "4.10.0.40961",
     "python_version": "3",
+    "fips_compliant": true,
     "app_wizard_version": "1.0.0",
     "latest_tested_versions": [
         "On-prem, Version: 3.0.9, 09/22/2021"

--- a/thehive_display_get_observables.html
+++ b/thehive_display_get_observables.html
@@ -11,8 +11,16 @@
 
 <!-- File: thehive_display_get_observables.html
   Copyright (c) 2018-2021 Splunk Inc.
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
 
-  Licensed under Apache 2.0 (https://www.apache.org/licenses/LICENSE-2.0.txt)
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software distributed under
+  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+  either express or implied. See the License for the specific language governing permissions
+  and limitations under the License.
 -->
 
 <style>


### PR DESCRIPTION
- Mark app as fips_compliant
- Fix bad Copyright text